### PR TITLE
Add CountBy benchmarks

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -601,7 +601,7 @@ function InitializeBuildTool() {
       ExitWithExitCode 1
     }
     $dotnetPath = Join-Path $dotnetRoot (GetExecutableFileName 'dotnet')
-    $buildTool = @{ Path = $dotnetPath; Command = 'msbuild'; Tool = 'dotnet'; Framework = 'net8.0' }
+    $buildTool = @{ Path = $dotnetPath; Command = 'msbuild'; Tool = 'dotnet'; Framework = 'net9.0' }
   } elseif ($msbuildEngine -eq "vs") {
     try {
       $msbuildPath = InitializeVisualStudioMSBuild -install:$restore

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -341,7 +341,7 @@ function InitializeBuildTool {
   # return values
   _InitializeBuildTool="$_InitializeDotNetCli/dotnet"
   _InitializeBuildToolCommand="msbuild"
-  _InitializeBuildToolFramework="net8.0"
+  _InitializeBuildToolFramework="net9.0"
 }
 
 # Set RestoreNoCache as a workaround for https://github.com/NuGet/Home/issues/3116

--- a/eng/performance/sdk_scenarios.proj
+++ b/eng/performance/sdk_scenarios.proj
@@ -10,6 +10,7 @@
       <Framework Include="net6.0" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '5.0'"/>
       <Framework Include="net7.0" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '6.0'"/>
       <Framework Include="net8.0" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '7.0'"/>
+      <Framework Include="net9.0" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '8.0'"/>
   </ItemGroup>
 
   <ItemDefinitionGroup>

--- a/helix.yml
+++ b/helix.yml
@@ -6,7 +6,7 @@ jobs:
     variables:
       architecture: 'x64'
       queue: ''
-      framework: 'net8.0'
+      framework: 'net9.0'
       runCategories: ''
       kind: ''
       runtimeRepoDir: '../runtime' # A guess that the performance repo is next to the runtime repo

--- a/scripts/benchmarks_local.py
+++ b/scripts/benchmarks_local.py
@@ -535,7 +535,7 @@ def add_arguments(parser):
     parser.add_argument('--architecture', choices=['x64', 'x86', 'arm64', 'arm'], default=get_machine_architecture(), help='Specifies the SDK processor architecture')
     parser.add_argument('--os', choices=['windows', 'linux', 'osx'], default=get_default_os(), help='Specifies the operating system of the system')
     parser.add_argument('--filter', type=str, default='*', help='Specifies the benchmark filter to pass to BenchmarkDotNet')
-    parser.add_argument('-f', '--framework', choices=ChannelMap.get_supported_frameworks(), default='net8.0', help='The target framework to run the benchmarks against.') # Can and should this accept multiple frameworks?
+    parser.add_argument('-f', '--framework', choices=ChannelMap.get_supported_frameworks(), default='net9.0', help='The target framework to run the benchmarks against.') # Can and should this accept multiple frameworks?
     parser.add_argument('--csproj', type=str, default=os.path.join("..", "src", "benchmarks", "micro", "MicroBenchmarks.csproj"), help='The path to the csproj file to run benchmarks against.')   
     parser.add_argument('--wasm-engine-path', type=str, help='The full path to the wasm engine to use for the benchmarks. e.g. /usr/local/bin/v8') 
 

--- a/scripts/channel_map.py
+++ b/scripts/channel_map.py
@@ -3,8 +3,8 @@ from typing import List, Optional, Set
 class ChannelMap():
     channel_map = {
         'main': {
-            'tfm': 'net8.0',
-            'branch': '8.0',
+            'tfm': 'net9.0',
+            'branch': '9.0',
             'quality': 'daily'
         },
         '8.0': {

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -84,6 +84,8 @@ class FrameworkAction(Action):
             return 'net7.0'
         if framework == 'nativeaot8.0':
             return 'net8.0'
+        if framework == 'nativeaot9.0':
+            return 'net9.0'
         else:
             return framework
 

--- a/scripts/micro_benchmarks.py
+++ b/scripts/micro_benchmarks.py
@@ -268,6 +268,8 @@ def __get_benchmarkdotnet_arguments(framework: str, args: Any) -> List[str]:
             run_args += ['--runtimes', 'wasmnet70']
         elif framework == "net8.0":
             run_args += ['--runtimes', 'wasmnet80']
+        elif framework == "net9.0":
+            run_args += ['--runtimes', 'wasmnet90']
 
     # Increase default 2 min build timeout to accommodate slow (or even very slow) hardware
     if not args.bdn_arguments or '--buildTimeout' not in args.bdn_arguments:

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -1,11 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <!-- Used by Python script to narrow down the specified target frameworks to test, and avoid downloading all supported SDKs -->
     <TargetFrameworks>$(PERFLAB_TARGET_FRAMEWORKS)</TargetFrameworks>
     <!-- Supported target frameworks -->
-    <TargetFrameworks Condition="'$(TargetFrameworks)' == '' AND '$(OS)' == 'Windows_NT'">net462;net6.0;net7.0;net8.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(TargetFrameworks)' == '' AND '$(OS)' != 'Windows_NT'">net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == '' AND '$(OS)' == 'Windows_NT'">net462;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == '' AND '$(OS)' != 'Windows_NT'">net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CS8002</NoWarn>
     <!-- Suppress binaryformatter obsolete warning -->
     <NoWarn>$(NoWarn);SYSLIB0011</NoWarn>
@@ -37,7 +37,7 @@
             <SystemVersion>7.0.0</SystemVersion>
         </PropertyGroup>
     </When>
-    <When Condition="'$(TargetFramework)' == 'net8.0'">
+    <When Condition="'$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net9.0'">
         <PropertyGroup>
             <LangVersion>preview</LangVersion>
             <ExtensionsVersion>$(MicrosoftExtensionsLoggingPackageVersion)</ExtensionsVersion>

--- a/src/benchmarks/micro/runtime/Linq/Linq.cs
+++ b/src/benchmarks/micro/runtime/Linq/Linq.cs
@@ -118,7 +118,8 @@ public class LinqBenchmarks
     public const int IterationsWhere01 = 250000;
     public const int IterationsCount00 = 1000000;
     public const int IterationsOrder00 = 25000;
-    
+    public const int IterationsCountBy00 = 1000000;
+
     #region Where00
 
     [Benchmark]
@@ -354,6 +355,56 @@ public class LinqBenchmarks
         }
 
         return (medianPricedProduct.ProductID == 57);
+    }
+    #endregion
+
+    #region CountBy00
+
+#if NET9_0_OR_GREATER
+    [Benchmark]
+    public bool CountBy00LinqMethodX()
+    {
+        List<Product> products = Product.GetProductList();
+        int count = 0;
+        for (int i = 0; i < IterationsCount00; i++)
+        {
+            count += products.CountBy(p => p.Category).Count();
+        }
+
+        return (count == 5 * IterationsCountBy00);
+    }
+#endif
+
+    [Benchmark]
+    public bool CountBy00GroupByX()
+    {
+        List<Product> products = Product.GetProductList();
+        int count = 0;
+        for (int i = 0; i < IterationsCount00; i++)
+        {
+            count += products
+                .GroupBy(p => p.Category)
+                .ToDictionary(c => c, g => g.Count())
+                .Count();
+        }
+
+        return (count == 5 * IterationsCountBy00);
+    }
+
+    [Benchmark]
+    public bool CountBy00LookupX()
+    {
+        List<Product> products = Product.GetProductList();
+        int count = 0;
+        for (int i = 0; i < IterationsCount00; i++)
+        {
+            count += products
+                .ToLookup(p => p.Category)
+                .ToDictionary(c => c, g => g.Count())
+                .Count();
+        }
+
+        return (count == 5 * IterationsCountBy00);
     }
     #endregion
 }


### PR DESCRIPTION
Adding benchmarks for the new CountBy Linq method.
See https://github.com/dotnet/runtime/pull/91507

I have tried to add support for the net9.0 TFM as it is now the one used in the main branch of the [dotnet/runtime](https://github.com/dotnet/runtime) repo but I don't know what I'm getting into...